### PR TITLE
Fix links to code samples 08,09

### DIFF
--- a/c++/04_custom_types/readme.md
+++ b/c++/04_custom_types/readme.md
@@ -64,9 +64,9 @@ PPP: 9.6
 CPL: 3.2.1.1 (for a quick example), chap 18 for all the details
 
 
-## 07_constructor_destructor.cpp
+## 08_constructor_destructor.cpp
 
-[link to file](./07_constructor_destructor.cpp)
+[link to file](./08_constructor_destructor.cpp)
 
 This example introduces you to the concepts of *constructor* and *destructor* of a class. Here you can also find the first example of *operator overloading*.
 
@@ -75,9 +75,9 @@ CPL: chap 16.2.5 constructors, chap 17.2 constructors and destructors, chap 18 o
 
 
 
-## 08_template_class.cpp
+## 09_template_class.cpp
 
-[link to file](./08_template_class.cpp)
+[link to file](./09_template_class.cpp)
 
 A naive implementation of a vector class, using the template for the type stored in the vector.
 

--- a/c++/04_custom_types/readme.md
+++ b/c++/04_custom_types/readme.md
@@ -84,7 +84,7 @@ A naive implementation of a vector class, using the template for the type stored
 
 
 
-###References:
+### References:
 
 [PPP] = Programming: Principles and Practice using C++ (Second Edition), Bjarne Stroustrup, Addison-Wesley 2014, ISBN 978-0-321-99278-9
 


### PR DESCRIPTION
In this PR I fixed the links to `08_constructor_destructor.cpp` and `09_template_class.cpp` in `04_custom_types/readme.md`.

PS. The file `04_custom_types/07_multiple_flags.cpp` is not mentioned in the readme.